### PR TITLE
VCF to Zarr example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # custom ignores
 opt
+data
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# custom ignores
+opt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/activate.sh
+++ b/activate.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# convenience script to activate the conda environment
+# usage: source activate.sh
+
+# add miniconda to the path
+export PATH=./opt/miniconda/bin:$PATH
+
+# activate conda environment
+source activate genomics-benchmarks

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,18 @@
+channels:
+- conda-forge
+- defaults
+dependencies:
+- python=3.6
+- matplotlib=2.2.2
+- numpy=1.14.5
+- pandas=0.23.1
+- scipy=1.1.0
+- seaborn=0.8.1
+- jupyter=1.0.0
+- notebook=5.5.0
+- ipykernel=4.8.2
+- dask=0.18.0
+- numcodecs=0.5.5
+- zarr=2.2.0
+- scikit-allel=1.1.10
+

--- a/install-conda.sh
+++ b/install-conda.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Convenience script to install miniconda.
+
+# N.B., assume this will be executed from the root directory of the repo.
+
+# ensure script errors if any command fails
+set -e
+
+# installation directory
+mkdir -pv opt
+
+# install miniconda
+if [ ! -f opt/miniconda.installed ]; then
+    echo "installing miniconda..."
+
+    cd opt
+
+    # clean up any previous
+    rm -rf miniconda
+
+    # download miniconda
+    wget --no-clobber https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+
+    # install miniconda
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p miniconda
+
+    # put conda on the path
+    export PATH=./miniconda/bin:$PATH
+
+    # create environment
+    conda env create --name genomics-benchmarks --file ../environment.yml
+
+    # mark success
+    touch miniconda.installed
+
+    cd ..
+
+else
+    echo "miniconda already installed"
+fi
+

--- a/notebooks/1000-genomes-vcf-to-zarr.ipynb
+++ b/notebooks/1000-genomes-vcf-to-zarr.ipynb
@@ -1,0 +1,677 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Convert human 1000 genomes phase 3 data from VCF to Zarr\n",
+    "\n",
+    "This notebook has example code for converting variant data from the 1000 genomes project phase 3 to Zarr format. \n",
+    "\n",
+    "This notebook uses a single chromosome as an example, however code could be adapted to run all chromosomes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import sys\n",
+    "import functools\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'1.1.10'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Use scikit-allel for the VCF to Zarr conversion.\n",
+    "import allel\n",
+    "allel.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0.5.5'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The numcodecs package holds the various compressors that can be used with Zarr.\n",
+    "import numcodecs\n",
+    "from numcodecs import Blosc\n",
+    "numcodecs.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'2.2.0'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import zarr\n",
+    "zarr.__version__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download and inspect source data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is a local directory where we will download VCF files to, and also write Zarr outputs.\n",
+    "data_path = Path('../data/1000genomes/release/20130502')\n",
+    "!mkdir -pv {data_path}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# There is one VCF file per chromosome.\n",
+    "vcf_path_template = str(data_path / 'ALL.chr{chrom}.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File ‘ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz’ already there; not retrieving.\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Download data for chromosome 22.\n",
+    "!cd {data_path} && wget --no-clobber {vcf_path_template.format(chrom='22')}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-rw-r--r-- 1 aliman aliman 205M Jun 21 15:22 ../data/1000genomes/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Inspect file size for interest.\n",
+    "!ls -lh {vcf_path_template.format(chrom='22')}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "##INFO=<ID=CIEND,Number=2,Type=Integer,Description=\"Confidence interval around END for imprecise variants\">\r\n",
+      "##INFO=<ID=CIPOS,Number=2,Type=Integer,Description=\"Confidence interval around POS for imprecise variants\">\r\n",
+      "##INFO=<ID=CS,Number=1,Type=String,Description=\"Source call set.\">\r\n",
+      "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End coordinate of this variant\">\r\n",
+      "##INFO=<ID=IMPRECISE,Number=0,Type=Flag,Description=\"Imprecise structural variation\">\r\n",
+      "##INFO=<ID=MC,Number=.,Type=String,Description=\"Merged calls.\">\r\n",
+      "##INFO=<ID=MEINFO,Number=4,Type=String,Description=\"Mobile element info of the form NAME,START,END<POLARITY; If there is only 5' OR 3' support for this call, will be NULL NULL for START and END\">\r\n",
+      "##INFO=<ID=MEND,Number=1,Type=Integer,Description=\"Mitochondrial end coordinate of inserted sequence\">\r\n",
+      "##INFO=<ID=MLEN,Number=1,Type=Integer,Description=\"Estimated length of mitochondrial insert\">\r\n",
+      "##INFO=<ID=MSTART,Number=1,Type=Integer,Description=\"Mitochondrial start coordinate of inserted sequence\">\r\n",
+      "##INFO=<ID=SVLEN,Number=.,Type=Integer,Description=\"SV length. It is only calculated for structural variation MEIs. For other types of SVs; one may calculate the SV length by INFO:END-START+1, or by finding the difference between lengthes of REF and ALT alleles\">\r\n",
+      "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type of structural variant\">\r\n",
+      "##INFO=<ID=TSD,Number=1,Type=String,Description=\"Precise Target Site Duplication for bases, if unknown, value will be NULL\">\r\n",
+      "##INFO=<ID=AC,Number=A,Type=Integer,Description=\"Total number of alternate alleles in called genotypes\">\r\n",
+      "##INFO=<ID=AF,Number=A,Type=Float,Description=\"Estimated allele frequency in the range (0,1)\">\r\n",
+      "##INFO=<ID=NS,Number=1,Type=Integer,Description=\"Number of samples with data\">\r\n",
+      "##INFO=<ID=AN,Number=1,Type=Integer,Description=\"Total number of alleles in called genotypes\">\r\n",
+      "##INFO=<ID=EAS_AF,Number=A,Type=Float,Description=\"Allele frequency in the EAS populations calculated from AC and AN, in the range (0,1)\">\r\n",
+      "##INFO=<ID=EUR_AF,Number=A,Type=Float,Description=\"Allele frequency in the EUR populations calculated from AC and AN, in the range (0,1)\">\r\n",
+      "##INFO=<ID=AFR_AF,Number=A,Type=Float,Description=\"Allele frequency in the AFR populations calculated from AC and AN, in the range (0,1)\">\r\n",
+      "##INFO=<ID=AMR_AF,Number=A,Type=Float,Description=\"Allele frequency in the AMR populations calculated from AC and AN, in the range (0,1)\">\r\n",
+      "##INFO=<ID=SAS_AF,Number=A,Type=Float,Description=\"Allele frequency in the SAS populations calculated from AC and AN, in the range (0,1)\">\r\n",
+      "##INFO=<ID=DP,Number=1,Type=Integer,Description=\"Total read depth; only low coverage data were counted towards the DP, exome data were not used\">\r\n",
+      "##INFO=<ID=AA,Number=1,Type=String,Description=\"Ancestral Allele. Format: AA|REF|ALT|IndelType. AA: Ancestral allele, REF:Reference Allele, ALT:Alternate Allele, IndelType:Type of Indel (REF, ALT and IndelType are only defined for indels)\">\r\n",
+      "##INFO=<ID=VT,Number=.,Type=String,Description=\"indicates what type of variant the line represents\">\r\n",
+      "##INFO=<ID=EX_TARGET,Number=0,Type=Flag,Description=\"indicates whether a variant is within the exon pull down target boundaries\">\r\n",
+      "##INFO=<ID=MULTI_ALLELIC,Number=0,Type=Flag,Description=\"indicates whether a site is multi-allelic\">\r\n",
+      "\r\n",
+      "gzip: stdout: Broken pipe\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Inspect which INFO fields are present, for interest.\n",
+    "!zcat {vcf_path_template.format(chrom='22')} | head -n1000 | grep INFO="
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\r\n",
+      "\r\n",
+      "gzip: stdout: Broken pipe\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Inspect which FORMAT fields are present, for interest.\n",
+    "!zcat {vcf_path_template.format(chrom='22')} | head -n1000 | grep FORMAT="
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convert VCF to Zarr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For a lossless conversion from VCF to Zarr, we will need to know the \n",
+    "# maximum number of alternate alleles found in any variant. This will be used to\n",
+    "# determine the shape of some arrays, like ALT for example.\n",
+    "\n",
+    "@functools.lru_cache(maxsize=None)\n",
+    "def find_alt_number(chrom):\n",
+    "    \"\"\"Scan a VCF to find the maximum number of alleles in any variant.\"\"\"\n",
+    "    vcf_path = vcf_path_template.format(chrom=chrom)\n",
+    "    callset = allel.read_vcf(vcf_path, fields=['numalt'], log=sys.stdout)\n",
+    "    numalt = callset['variants/numalt']\n",
+    "    return np.max(numalt)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[read_vcf] 65536 rows in 5.26s; chunk in 5.26s (12463 rows/s); 22\u0000:18539397\n",
+      "[read_vcf] 131072 rows in 10.51s; chunk in 5.25s (12486 rows/s); 22\u0000:21016127\n",
+      "[read_vcf] 196608 rows in 16.01s; chunk in 5.50s (11907 rows/s); 22\u0000:23236362\n",
+      "[read_vcf] 262144 rows in 21.13s; chunk in 5.12s (12788 rows/s); 22\u0000:25227844\n",
+      "[read_vcf] 327680 rows in 26.25s; chunk in 5.11s (12815 rows/s); 22\u0000:27285434\n",
+      "[read_vcf] 393216 rows in 31.34s; chunk in 5.09s (12874 rows/s); 22\u0000:29572822\n",
+      "[read_vcf] 458752 rows in 36.55s; chunk in 5.21s (12582 rows/s); 22\u0000:31900536\n",
+      "[read_vcf] 524288 rows in 43.06s; chunk in 6.51s (10067 rows/s); 22\u0000:34069864\n",
+      "[read_vcf] 589824 rows in 48.19s; chunk in 5.13s (12775 rows/s); 22\u0000:36053392\n",
+      "[read_vcf] 655360 rows in 54.19s; chunk in 6.01s (10909 rows/s); 22\u0000:38088395\n",
+      "[read_vcf] 720896 rows in 59.57s; chunk in 5.38s (12181 rows/s); 22\u0000:40216200\n",
+      "[read_vcf] 786432 rows in 64.94s; chunk in 5.37s (12204 rows/s); 22\u0000:42597446\n",
+      "[read_vcf] 851968 rows in 70.29s; chunk in 5.35s (12257 rows/s); 22\u0000:44564263\n",
+      "[read_vcf] 917504 rows in 79.41s; chunk in 9.12s (7184 rows/s); 22\u0000:46390672\n",
+      "[read_vcf] 983040 rows in 85.84s; chunk in 6.43s (10189 rows/s); 22\u0000:48116697\n",
+      "[read_vcf] 1048576 rows in 92.26s; chunk in 6.42s (10205 rows/s); 22\u0000:49713436\n",
+      "[read_vcf] 1103547 rows in 97.09s; chunk in 4.83s (11382 rows/s)\n",
+      "[read_vcf] all done (11365 rows/s)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "8"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Demonstrate finding max number of alternate alleles.\n",
+    "find_alt_number('22')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_zarr(zarr_path, chrom, compressor, fields='*'):\n",
+    "    \"\"\"Run VCF to Zarr conversion for the given chromosome.\"\"\"\n",
+    "    \n",
+    "    # Determine VCF path for this chromosome.\n",
+    "    vcf_path = vcf_path_template.format(chrom=chrom)\n",
+    "    \n",
+    "    # Zarr can't handle pathlib.Path, ensure string\n",
+    "    zarr_path = str(zarr_path)  \n",
+    "    \n",
+    "    # Determine max number of ALT alleles.\n",
+    "    alt_number = find_alt_number(chrom)\n",
+    "    \n",
+    "    # Run VCF to Zarr converation. For all the options that this function supports, see\n",
+    "    # http://alimanfoo.github.io/2017/06/14/read-vcf.html\n",
+    "    allel.vcf_to_zarr(vcf_path, zarr_path, group=chrom, fields=fields, \n",
+    "                      alt_number=alt_number, log=sys.stdout, compressor=compressor)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Choose a compressor - this one is a good allrounder, good compression ratio and reasonable speed.\n",
+    "# Should work well on both local and networked storage.\n",
+    "compressor = Blosc(cname='zstd', clevel=1, shuffle=Blosc.AUTOSHUFFLE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zarr_path = data_path / 'zarr'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[vcf_to_zarr] 65536 rows in 11.59s; chunk in 11.59s (5653 rows/s); 22\u0000:18539397\n",
+      "[vcf_to_zarr] 131072 rows in 24.01s; chunk in 12.42s (5275 rows/s); 22\u0000:21016127\n",
+      "[vcf_to_zarr] 196608 rows in 36.98s; chunk in 12.97s (5053 rows/s); 22\u0000:23236362\n",
+      "[vcf_to_zarr] 262144 rows in 50.06s; chunk in 13.08s (5009 rows/s); 22\u0000:25227844\n",
+      "[vcf_to_zarr] 327680 rows in 64.26s; chunk in 14.20s (4614 rows/s); 22\u0000:27285434\n",
+      "[vcf_to_zarr] 393216 rows in 77.75s; chunk in 13.49s (4857 rows/s); 22\u0000:29572822\n",
+      "[vcf_to_zarr] 458752 rows in 90.09s; chunk in 12.34s (5310 rows/s); 22\u0000:31900536\n",
+      "[vcf_to_zarr] 524288 rows in 102.63s; chunk in 12.54s (5227 rows/s); 22\u0000:34069864\n",
+      "[vcf_to_zarr] 589824 rows in 115.25s; chunk in 12.61s (5195 rows/s); 22\u0000:36053392\n",
+      "[vcf_to_zarr] 655360 rows in 127.33s; chunk in 12.09s (5421 rows/s); 22\u0000:38088395\n",
+      "[vcf_to_zarr] 720896 rows in 138.22s; chunk in 10.89s (6019 rows/s); 22\u0000:40216200\n",
+      "[vcf_to_zarr] 786432 rows in 149.82s; chunk in 11.60s (5649 rows/s); 22\u0000:42597446\n",
+      "[vcf_to_zarr] 851968 rows in 161.99s; chunk in 12.17s (5386 rows/s); 22\u0000:44564263\n",
+      "[vcf_to_zarr] 917504 rows in 172.90s; chunk in 10.91s (6007 rows/s); 22\u0000:46390672\n",
+      "[vcf_to_zarr] 983040 rows in 183.65s; chunk in 10.75s (6097 rows/s); 22\u0000:48116697\n",
+      "[vcf_to_zarr] 1048576 rows in 194.59s; chunk in 10.95s (5986 rows/s); 22\u0000:49713436\n",
+      "[vcf_to_zarr] 1103547 rows in 203.72s; chunk in 9.13s (6022 rows/s)\n",
+      "[vcf_to_zarr] all done (5404 rows/s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "build_zarr(zarr_path, chrom='22', compressor=compressor)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect Zarr output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "110M\t../data/1000genomes/release/20130502/zarr\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Inspect total size of Zarr data.\n",
+    "!du -hs {str(zarr_path)}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "73M\t../data/1000genomes/release/20130502/zarr/22/calldata/GT\r\n",
+      "28K\t../data/1000genomes/release/20130502/zarr/22/samples/0\r\n",
+      "2.0M\t../data/1000genomes/release/20130502/zarr/22/variants/AA\r\n",
+      "1.3M\t../data/1000genomes/release/20130502/zarr/22/variants/AC\r\n",
+      "3.3M\t../data/1000genomes/release/20130502/zarr/22/variants/AF\r\n",
+      "3.3M\t../data/1000genomes/release/20130502/zarr/22/variants/AFR_AF\r\n",
+      "2.4M\t../data/1000genomes/release/20130502/zarr/22/variants/ALT\r\n",
+      "2.7M\t../data/1000genomes/release/20130502/zarr/22/variants/AMR_AF\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/AN\r\n",
+      "76K\t../data/1000genomes/release/20130502/zarr/22/variants/CHROM\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/CIEND\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/CIPOS\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/CS\r\n",
+      "2.0M\t../data/1000genomes/release/20130502/zarr/22/variants/DP\r\n",
+      "2.4M\t../data/1000genomes/release/20130502/zarr/22/variants/EAS_AF\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/END\r\n",
+      "2.4M\t../data/1000genomes/release/20130502/zarr/22/variants/EUR_AF\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/EX_TARGET\r\n",
+      "76K\t../data/1000genomes/release/20130502/zarr/22/variants/FILTER_PASS\r\n",
+      "7.9M\t../data/1000genomes/release/20130502/zarr/22/variants/ID\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/IMPRECISE\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/MC\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/MEINFO\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/MEND\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/MLEN\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/MSTART\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/MULTI_ALLELIC\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/NS\r\n",
+      "1.4M\t../data/1000genomes/release/20130502/zarr/22/variants/POS\r\n",
+      "76K\t../data/1000genomes/release/20130502/zarr/22/variants/QUAL\r\n",
+      "1.2M\t../data/1000genomes/release/20130502/zarr/22/variants/REF\r\n",
+      "2.6M\t../data/1000genomes/release/20130502/zarr/22/variants/SAS_AF\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/SVLEN\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/SVTYPE\r\n",
+      "80K\t../data/1000genomes/release/20130502/zarr/22/variants/TSD\r\n",
+      "736K\t../data/1000genomes/release/20130502/zarr/22/variants/VT\r\n",
+      "76K\t../data/1000genomes/release/20130502/zarr/22/variants/is_snp\r\n",
+      "76K\t../data/1000genomes/release/20130502/zarr/22/variants/numalt\r\n",
+      "412K\t../data/1000genomes/release/20130502/zarr/22/variants/svlen\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Inspect size breakdown of Zarr data.\n",
+    "!du -hs {str(zarr_path / '*' / '*' / '*')}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"db5755da-5e45-4af0-9465-90a1ba43d88f\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>22</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>calldata</span><ul><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>GT (1103547, 2504, 2) int8</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>samples (2504,) object</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>variants</span><ul><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>AA (1103547,) object</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>AC (1103547, 8) int32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>AF (1103547, 8) float32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>AFR_AF (1103547, 8) float32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>ALT (1103547, 8) object</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>AMR_AF (1103547, 8) float32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>AN (1103547,) int32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>CHROM (1103547,) object</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>CIEND (1103547, 2) int32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>CIPOS (1103547, 2) int32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>CS (1103547,) object</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>DP (1103547,) int32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>EAS_AF (1103547, 8) float32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>END (1103547,) int32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>EUR_AF (1103547, 8) float32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>EX_TARGET (1103547,) bool</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>FILTER_PASS (1103547,) bool</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>ID (1103547,) object</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>IMPRECISE (1103547,) bool</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>MC (1103547,) object</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>MEINFO (1103547, 4) object</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>MEND (1103547,) int32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>MLEN (1103547,) int32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>MSTART (1103547,) int32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>MULTI_ALLELIC (1103547,) bool</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>NS (1103547,) int32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>POS (1103547,) int32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>QUAL (1103547,) float32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>REF (1103547,) object</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>SAS_AF (1103547, 8) float32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>SVLEN (1103547,) int32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>SVTYPE (1103547,) object</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>TSD (1103547,) object</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>VT (1103547,) object</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>is_snp (1103547,) bool</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>numalt (1103547,) int32</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>svlen (1103547, 8) int32</span></li></ul></li></ul></li></ul></li></ul></div>\n",
+       "<script>\n",
+       "    if (!require.defined('jquery')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    if (!require.defined('jstree')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jstree: '//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/jstree.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    require(['jstree'], function() {\n",
+       "        $('#db5755da-5e45-4af0-9465-90a1ba43d88f').jstree({\n",
+       "            types: {\n",
+       "                Group: {\n",
+       "                    icon: \"fa fa-folder\"\n",
+       "                },\n",
+       "                Array: {\n",
+       "                    icon: \"fa fa-table\"\n",
+       "                }\n",
+       "            },\n",
+       "            plugins: [\"types\"]\n",
+       "        });\n",
+       "    });\n",
+       "</script>\n"
+      ],
+      "text/plain": [
+       "/\n",
+       " └── 22\n",
+       "     ├── calldata\n",
+       "     │   └── GT (1103547, 2504, 2) int8\n",
+       "     ├── samples (2504,) object\n",
+       "     └── variants\n",
+       "         ├── AA (1103547,) object\n",
+       "         ├── AC (1103547, 8) int32\n",
+       "         ├── AF (1103547, 8) float32\n",
+       "         ├── AFR_AF (1103547, 8) float32\n",
+       "         ├── ALT (1103547, 8) object\n",
+       "         ├── AMR_AF (1103547, 8) float32\n",
+       "         ├── AN (1103547,) int32\n",
+       "         ├── CHROM (1103547,) object\n",
+       "         ├── CIEND (1103547, 2) int32\n",
+       "         ├── CIPOS (1103547, 2) int32\n",
+       "         ├── CS (1103547,) object\n",
+       "         ├── DP (1103547,) int32\n",
+       "         ├── EAS_AF (1103547, 8) float32\n",
+       "         ├── END (1103547,) int32\n",
+       "         ├── EUR_AF (1103547, 8) float32\n",
+       "         ├── EX_TARGET (1103547,) bool\n",
+       "         ├── FILTER_PASS (1103547,) bool\n",
+       "         ├── ID (1103547,) object\n",
+       "         ├── IMPRECISE (1103547,) bool\n",
+       "         ├── MC (1103547,) object\n",
+       "         ├── MEINFO (1103547, 4) object\n",
+       "         ├── MEND (1103547,) int32\n",
+       "         ├── MLEN (1103547,) int32\n",
+       "         ├── MSTART (1103547,) int32\n",
+       "         ├── MULTI_ALLELIC (1103547,) bool\n",
+       "         ├── NS (1103547,) int32\n",
+       "         ├── POS (1103547,) int32\n",
+       "         ├── QUAL (1103547,) float32\n",
+       "         ├── REF (1103547,) object\n",
+       "         ├── SAS_AF (1103547, 8) float32\n",
+       "         ├── SVLEN (1103547,) int32\n",
+       "         ├── SVTYPE (1103547,) object\n",
+       "         ├── TSD (1103547,) object\n",
+       "         ├── VT (1103547,) object\n",
+       "         ├── is_snp (1103547,) bool\n",
+       "         ├── numalt (1103547,) int32\n",
+       "         └── svlen (1103547, 8) int32"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Open the Zarr data and inspect the hierarchy.\n",
+    "store = zarr.DirectoryStore(str(zarr_path))\n",
+    "callset = zarr.Group(store=store, read_only=True)\n",
+    "callset.tree(expand=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"zarr-info\"><tbody><tr><th style=\"text-align: left\">Name</th><td style=\"text-align: left\">/22/calldata/GT</td></tr><tr><th style=\"text-align: left\">Type</th><td style=\"text-align: left\">zarr.core.Array</td></tr><tr><th style=\"text-align: left\">Data type</th><td style=\"text-align: left\">int8</td></tr><tr><th style=\"text-align: left\">Shape</th><td style=\"text-align: left\">(1103547, 2504, 2)</td></tr><tr><th style=\"text-align: left\">Chunk shape</th><td style=\"text-align: left\">(65536, 64, 2)</td></tr><tr><th style=\"text-align: left\">Order</th><td style=\"text-align: left\">C</td></tr><tr><th style=\"text-align: left\">Read-only</th><td style=\"text-align: left\">True</td></tr><tr><th style=\"text-align: left\">Compressor</th><td style=\"text-align: left\">Blosc(cname='zstd', clevel=1, shuffle=AUTOSHUFFLE, blocksize=0)</td></tr><tr><th style=\"text-align: left\">Store type</th><td style=\"text-align: left\">zarr.storage.DirectoryStore</td></tr><tr><th style=\"text-align: left\">No. bytes</th><td style=\"text-align: left\">5526563376 (5.1G)</td></tr><tr><th style=\"text-align: left\">No. bytes stored</th><td style=\"text-align: left\">74640281 (71.2M)</td></tr><tr><th style=\"text-align: left\">Storage ratio</th><td style=\"text-align: left\">74.0</td></tr><tr><th style=\"text-align: left\">Chunks initialized</th><td style=\"text-align: left\">680/680</td></tr></tbody></table>"
+      ],
+      "text/plain": [
+       "Name               : /22/calldata/GT\n",
+       "Type               : zarr.core.Array\n",
+       "Data type          : int8\n",
+       "Shape              : (1103547, 2504, 2)\n",
+       "Chunk shape        : (65536, 64, 2)\n",
+       "Order              : C\n",
+       "Read-only          : True\n",
+       "Compressor         : Blosc(cname='zstd', clevel=1, shuffle=AUTOSHUFFLE,\n",
+       "                   : blocksize=0)\n",
+       "Store type         : zarr.storage.DirectoryStore\n",
+       "No. bytes          : 5526563376 (5.1G)\n",
+       "No. bytes stored   : 74640281 (71.2M)\n",
+       "Storage ratio      : 74.0\n",
+       "Chunks initialized : 680/680"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Get some diagnostics on the genotype data.\n",
+    "gtz = callset['22/calldata/GT']\n",
+    "gtz.info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 30.9 s, sys: 398 ms, total: 31.3 s\n",
+      "Wall time: 4.31 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# Do a quick benchmark of time to compute allele counts over whole chromosome and cohort.\n",
+    "\n",
+    "# Wrap Zarr array with scikit-allel class.\n",
+    "gt = allel.GenotypeDaskArray(gtz)\n",
+    "\n",
+    "# It helps to know the max number of ALT alleles to expect.\n",
+    "max_allele = callset['22/variants/ALT'].shape[1]\n",
+    "\n",
+    "# Run the computation.\n",
+    "ac = gt.count_alleles(max_allele=max_allele).compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"allel allel-DisplayAs2D\"><span>&lt;AlleleCountsArray shape=(1103547, 9) dtype=int64&gt;</span><table><thead><tr><th></th><th style=\"text-align: center\">0</th><th style=\"text-align: center\">1</th><th style=\"text-align: center\">2</th><th style=\"text-align: center\">3</th><th style=\"text-align: center\">4</th><th style=\"text-align: center\">5</th><th style=\"text-align: center\">6</th><th style=\"text-align: center\">7</th><th style=\"text-align: center\">8</th></tr></thead><tbody><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">0</th><td style=\"text-align: center\">5007</td><td style=\"text-align: center\">   1</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1</th><td style=\"text-align: center\">4976</td><td style=\"text-align: center\">  32</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">2</th><td style=\"text-align: center\">4970</td><td style=\"text-align: center\">  38</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">...</th><td style=\"text-align: center\" colspan=\"10\">...</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1103544</th><td style=\"text-align: center\">4969</td><td style=\"text-align: center\">  39</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1103545</th><td style=\"text-align: center\">5007</td><td style=\"text-align: center\">   1</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1103546</th><td style=\"text-align: center\">4989</td><td style=\"text-align: center\">  19</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "<AlleleCountsArray shape=(1103547, 9) dtype=int64>\n",
+       "5007    1    0    0    0    0    0    0    0\n",
+       "4976   32    0    0    0    0    0    0    0\n",
+       "4970   38    0    0    0    0    0    0    0\n",
+       "...\n",
+       "4969   39    0    0    0    0    0    0    0\n",
+       "5007    1    0    0    0    0    0    0    0\n",
+       "4989   19    0    0    0    0    0    0    0"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# What does an allele counts array look like?\n",
+    "# Rows are variants, columns are alleles, each cell holds the count of observations of an allele for a variant.\n",
+    "ac"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds a notebook with example code for converting the human 1000 genomes phase 3 data from VCF to Zarr.

Also some files to define a conda environment so Python package versions are explicit.