### PR TITLE
Simple aggregations example notebook

### DIFF
--- a/notebooks/1000-genomes-simple-aggregations.ipynb
+++ b/notebooks/1000-genomes-simple-aggregations.ipynb
@@ -1,0 +1,761 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Simple aggregation examples\n",
+    "\n",
+    "This notebook illustrates some simple aggregations over genotype data via scikit-allel and dask, using data from 1000 genomes phase 3. Assumes data previously converted to zarr format.\n",
+    "\n",
+    "These examples demonstrate some one-step and two-step dask computations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import sys\n",
+    "import functools\n",
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'1.1.10'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import allel\n",
+    "allel.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'2.2.0'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import zarr\n",
+    "zarr.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_path = Path('../data/1000genomes/release/20130502')\n",
+    "zarr_path = data_path / 'zarr'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<zarr.hierarchy.Group '/' read-only>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "store = zarr.DirectoryStore(str(zarr_path))\n",
+    "callset = zarr.Group(store=store, read_only=True)\n",
+    "callset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# fix on a chromosome\n",
+    "chrom = '22'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<zarr.core.Array '/22/calldata/GT' (1103547, 2504, 2) int8 read-only>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# access genotype data\n",
+    "gtz = callset[chrom]['calldata/GT']\n",
+    "gtz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"zarr-info\"><tbody><tr><th style=\"text-align: left\">Name</th><td style=\"text-align: left\">/22/calldata/GT</td></tr><tr><th style=\"text-align: left\">Type</th><td style=\"text-align: left\">zarr.core.Array</td></tr><tr><th style=\"text-align: left\">Data type</th><td style=\"text-align: left\">int8</td></tr><tr><th style=\"text-align: left\">Shape</th><td style=\"text-align: left\">(1103547, 2504, 2)</td></tr><tr><th style=\"text-align: left\">Chunk shape</th><td style=\"text-align: left\">(65536, 64, 2)</td></tr><tr><th style=\"text-align: left\">Order</th><td style=\"text-align: left\">C</td></tr><tr><th style=\"text-align: left\">Read-only</th><td style=\"text-align: left\">True</td></tr><tr><th style=\"text-align: left\">Compressor</th><td style=\"text-align: left\">Blosc(cname='zstd', clevel=1, shuffle=AUTOSHUFFLE, blocksize=0)</td></tr><tr><th style=\"text-align: left\">Store type</th><td style=\"text-align: left\">zarr.storage.DirectoryStore</td></tr><tr><th style=\"text-align: left\">No. bytes</th><td style=\"text-align: left\">5526563376 (5.1G)</td></tr><tr><th style=\"text-align: left\">No. bytes stored</th><td style=\"text-align: left\">74640281 (71.2M)</td></tr><tr><th style=\"text-align: left\">Storage ratio</th><td style=\"text-align: left\">74.0</td></tr><tr><th style=\"text-align: left\">Chunks initialized</th><td style=\"text-align: left\">680/680</td></tr></tbody></table>"
+      ],
+      "text/plain": [
+       "Name               : /22/calldata/GT\n",
+       "Type               : zarr.core.Array\n",
+       "Data type          : int8\n",
+       "Shape              : (1103547, 2504, 2)\n",
+       "Chunk shape        : (65536, 64, 2)\n",
+       "Order              : C\n",
+       "Read-only          : True\n",
+       "Compressor         : Blosc(cname='zstd', clevel=1, shuffle=AUTOSHUFFLE,\n",
+       "                   : blocksize=0)\n",
+       "Store type         : zarr.storage.DirectoryStore\n",
+       "No. bytes          : 5526563376 (5.1G)\n",
+       "No. bytes stored   : 74640281 (71.2M)\n",
+       "Storage ratio      : 74.0\n",
+       "Chunks initialized : 680/680"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gtz.info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"allel allel-DisplayAs2D\"><span>&lt;GenotypeDaskArray shape=(1103547, 2504, 2) dtype=int8&gt;</span><table><thead><tr><th></th><th style=\"text-align: center\">0</th><th style=\"text-align: center\">1</th><th style=\"text-align: center\">2</th><th style=\"text-align: center\">3</th><th style=\"text-align: center\">4</th><th style=\"text-align: center\">...</th><th style=\"text-align: center\">2499</th><th style=\"text-align: center\">2500</th><th style=\"text-align: center\">2501</th><th style=\"text-align: center\">2502</th><th style=\"text-align: center\">2503</th></tr></thead><tbody><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">0</th><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1</th><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">2</th><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">...</th><td style=\"text-align: center\" colspan=\"12\">...</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1103544</th><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1103545</th><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1103546</th><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">...</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td><td style=\"text-align: center\">0/0</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "<GenotypeDaskArray shape=(1103547, 2504, 2) dtype=int8>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# wrap with scikit-allel array class\n",
+    "gt = allel.GenotypeDaskArray(gtz)\n",
+    "gt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File ‘integrated_call_samples_v3.20130502.ALL.panel’ already there; not retrieving.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Download sample metadata.\n",
+    "!cd {data_path} && wget --no-clobber ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/integrated_call_samples_v3.20130502.ALL.panel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sample</th>\n",
+       "      <th>pop</th>\n",
+       "      <th>super_pop</th>\n",
+       "      <th>gender</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>HG00096</td>\n",
+       "      <td>GBR</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>male</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>HG00097</td>\n",
+       "      <td>GBR</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>female</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>HG00099</td>\n",
+       "      <td>GBR</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>female</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>HG00100</td>\n",
+       "      <td>GBR</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>female</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>HG00101</td>\n",
+       "      <td>GBR</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>male</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    sample  pop super_pop  gender\n",
+       "0  HG00096  GBR       EUR    male\n",
+       "1  HG00097  GBR       EUR  female\n",
+       "2  HG00099  GBR       EUR  female\n",
+       "3  HG00100  GBR       EUR  female\n",
+       "4  HG00101  GBR       EUR    male"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Setup sample dataframe\n",
+    "df_samples = (\n",
+    "    pd.read_csv(data_path / 'integrated_call_samples_v3.20130502.ALL.panel', sep='\\t')\n",
+    "    [['sample', 'pop', 'super_pop', 'gender']]\n",
+    ")\n",
+    "df_samples.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "N.B., here we can assume that the order of the samples in the metadata file is the same as the order of the samples in the VCF (and therefore Zarr) files. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Count alleles\n",
+    "\n",
+    "The allele count computation simply counts, for each variant, the number of times each allele is observed. I.e., for each row, count how many 0s, 1s, 2s, etc.\n",
+    "\n",
+    "Some extra computation can be avoided if we know ahead of time what the largest allele value is within the genotype array. We can obtain this from the number of ALT values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "max_allele = callset[chrom]['variants/ALT'].shape[1]\n",
+    "max_allele"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This computation will be run via dask. By default, dask will use the multithreaded scheduler. See the dask documentation for how to configure different schedulers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### All samples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the allele count over the whole cohort (i.e., all samples)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 32.3 s, sys: 454 ms, total: 32.8 s\n",
+      "Wall time: 4.44 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "ac = gt.count_alleles(max_allele=max_allele).compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"allel allel-DisplayAs2D\"><span>&lt;AlleleCountsArray shape=(1103547, 9) dtype=int64&gt;</span><table><thead><tr><th></th><th style=\"text-align: center\">0</th><th style=\"text-align: center\">1</th><th style=\"text-align: center\">2</th><th style=\"text-align: center\">3</th><th style=\"text-align: center\">4</th><th style=\"text-align: center\">5</th><th style=\"text-align: center\">6</th><th style=\"text-align: center\">7</th><th style=\"text-align: center\">8</th></tr></thead><tbody><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">0</th><td style=\"text-align: center\">5007</td><td style=\"text-align: center\">   1</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1</th><td style=\"text-align: center\">4976</td><td style=\"text-align: center\">  32</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">2</th><td style=\"text-align: center\">4970</td><td style=\"text-align: center\">  38</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">...</th><td style=\"text-align: center\" colspan=\"10\">...</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1103544</th><td style=\"text-align: center\">4969</td><td style=\"text-align: center\">  39</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1103545</th><td style=\"text-align: center\">5007</td><td style=\"text-align: center\">   1</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1103546</th><td style=\"text-align: center\">4989</td><td style=\"text-align: center\">  19</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "<AlleleCountsArray shape=(1103547, 9) dtype=int64>\n",
+       "5007    1    0    0    0    0    0    0    0\n",
+       "4976   32    0    0    0    0    0    0    0\n",
+       "4970   38    0    0    0    0    0    0    0\n",
+       "...\n",
+       "4969   39    0    0    0    0    0    0    0\n",
+       "5007    1    0    0    0    0    0    0    0\n",
+       "4989   19    0    0    0    0    0    0    0"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ac"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sample subset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now run the allele count computation over a subset of samples. First select the samples to run, e.g., all Africans."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "661"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Obtain indices for African samples.\n",
+    "loc_african_samples = df_samples[df_samples.super_pop == 'AFR'].index.values\n",
+    "len(loc_african_samples)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the computation. N.B., this is a two-step computation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 42.4 s, sys: 260 ms, total: 42.7 s\n",
+      "Wall time: 5.61 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "ac_afr = gt.take(loc_african_samples, axis=1).count_alleles(max_allele=max_allele).compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"allel allel-DisplayAs2D\"><span>&lt;AlleleCountsArray shape=(1103547, 9) dtype=int64&gt;</span><table><thead><tr><th></th><th style=\"text-align: center\">0</th><th style=\"text-align: center\">1</th><th style=\"text-align: center\">2</th><th style=\"text-align: center\">3</th><th style=\"text-align: center\">4</th><th style=\"text-align: center\">5</th><th style=\"text-align: center\">6</th><th style=\"text-align: center\">7</th><th style=\"text-align: center\">8</th></tr></thead><tbody><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">0</th><td style=\"text-align: center\">1322</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1</th><td style=\"text-align: center\">1291</td><td style=\"text-align: center\">  31</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">2</th><td style=\"text-align: center\">1286</td><td style=\"text-align: center\">  36</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">...</th><td style=\"text-align: center\" colspan=\"10\">...</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1103544</th><td style=\"text-align: center\">1322</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1103545</th><td style=\"text-align: center\">1322</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr><tr><th style=\"text-align: center; background-color: white; border-right: 1px solid black; \">1103546</th><td style=\"text-align: center\">1322</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td><td style=\"text-align: center\">   0</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "<AlleleCountsArray shape=(1103547, 9) dtype=int64>\n",
+       "1322    0    0    0    0    0    0    0    0\n",
+       "1291   31    0    0    0    0    0    0    0\n",
+       "1286   36    0    0    0    0    0    0    0\n",
+       "...\n",
+       "1322    0    0    0    0    0    0    0    0\n",
+       "1322    0    0    0    0    0    0    0    0\n",
+       "1322    0    0    0    0    0    0    0    0"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ac_afr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Count genotypes\n",
+    "\n",
+    "Another simple aggregation is to count the number of occurrences of a given genotype (e.g., missing, homozygous reference, heterozygous, or homozygous alternate). This aggregation can either be performed over samples (i.e., count genotypes per variant) or over variants (i.e., count genotypes per sample)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Count per variant - all samples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1min 12s, sys: 192 ms, total: 1min 12s\n",
+      "Wall time: 9.31 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "hets_per_variant = gt.count_het(axis=1).compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 1, 32, 36, ..., 37,  1, 19])"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hets_per_variant"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Count per variant - sample subset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 41.4 s, sys: 109 ms, total: 41.6 s\n",
+      "Wall time: 5.42 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "hets_per_variant_afr = gt.take(loc_african_samples, axis=1).count_het(axis=1).compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 0, 31, 34, ...,  0,  0,  0])"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hets_per_variant_afr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Count per sample - all variants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1min 10s, sys: 127 ms, total: 1min 10s\n",
+      "Wall time: 9.09 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "hets_per_sample = gt.count_het(axis=0).compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([30154, 34053, 35291, ..., 40246, 40320, 38269])"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hets_per_sample"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Count per sample - variant subset\n",
+    "\n",
+    "Illustrate running a computation that first selects a subset of variants."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "573660"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# locate variants segregating in Africa\n",
+    "loc_african_variants = ac_afr.is_segregating()\n",
+    "np.count_nonzero(loc_african_variants)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 43.1 s, sys: 264 ms, total: 43.3 s\n",
+      "Wall time: 5.84 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "hets_per_sample_afr = gt.compress(loc_african_variants, axis=0).count_het(axis=0).compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([29612, 33338, 34654, ..., 38853, 38568, 36925])"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hets_per_sample_afr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/1000-genomes-vcf-to-zarr.ipynb
+++ b/notebooks/1000-genomes-vcf-to-zarr.ipynb
@@ -114,7 +114,14 @@
    "outputs": [],
    "source": [
     "# There is one VCF file per chromosome.\n",
-    "vcf_path_template = str(data_path / 'ALL.chr{chrom}.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz')"
+    "vcf_fn_template = 'ALL.chr{chrom}.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz'\n",
+    "\n",
+    "# Local path to download VCF to.\n",
+    "vcf_path_template = str(data_path / vcf_fn_template)\n",
+    "\n",
+    "# Remote FTP location.\n",
+    "ftp_path = 'ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502'\n",
+    "vcf_ftp_path_template = ftp_path + '/' + vcf_fn_template"
    ]
   },
   {
@@ -123,22 +130,63 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "File ‘ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz’ already there; not retrieving.\r\n",
-      "\r\n"
-     ]
+     "data": {
+      "text/plain": [
+       "'ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "# Download data for chromosome 22.\n",
-    "!cd {data_path} && wget --no-clobber {vcf_path_template.format(chrom='22')}"
+    "vcf_ftp_path = vcf_ftp_path_template.format(chrom='22')\n",
+    "vcf_ftp_path"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File ‘ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz’ already there; not retrieving.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!cd {data_path} && wget --no-clobber {vcf_ftp_path}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'../data/1000genomes/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vcf_path = vcf_path_template.format(chrom='22')\n",
+    "vcf_path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -151,12 +199,12 @@
    ],
    "source": [
     "# Inspect file size for interest.\n",
-    "!ls -lh {vcf_path_template.format(chrom='22')}"
+    "!ls -lh {vcf_path}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -197,12 +245,12 @@
    ],
    "source": [
     "# Inspect which INFO fields are present, for interest.\n",
-    "!zcat {vcf_path_template.format(chrom='22')} | head -n1000 | grep INFO="
+    "!zcat {vcf_path} | head -n1000 | grep INFO="
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -217,7 +265,7 @@
    ],
    "source": [
     "# Inspect which FORMAT fields are present, for interest.\n",
-    "!zcat {vcf_path_template.format(chrom='22')} | head -n1000 | grep FORMAT="
+    "!zcat {vcf_path} | head -n1000 | grep FORMAT="
    ]
   },
   {


### PR DESCRIPTION
This PR adds a notebook with some examples of running simple aggregations over genotype data. This includes allele counts, and also genotype counts aggregating over variants or samples.

Also fixes FTP location in the vcf-to-zarr notebook.