### PR TITLE
[VCF to Zarr] Expose alt_number, chunk_length, and chunk_width as Configuration Options

### DIFF
--- a/benchmark/config.py
+++ b/benchmark/config.py
@@ -100,6 +100,8 @@ class VCFtoZarrConfigurationRepresentation:
     """ Utility class for object representation of VCF to Zarr conversion module configuration. """
     enabled = False  # Specifies whether the VCF to Zarr conversion module should be enabled or not
     alt_number = None  # Alt number to use when converting to Zarr format. If None, then this will need to be determined
+    chunk_length = None  # Number of variants of chunks in which data are processed. If None, use default value
+    chunk_width = None  # Number of samples to use when storing chunks in output. If None, use default value
     compressor = "Blosc"  # Specifies compressor type to use for Zarr conversion
     blosc_compression_algorithm = "zstd"
     blosc_compression_level = 1  # Level of compression to use for Zarr conversion
@@ -124,7 +126,18 @@ class VCFtoZarrConfigurationRepresentation:
                         self.alt_number = None
                     elif isint(alt_number_str):
                         self.alt_number = int(alt_number_str)
-
+                if "chunk_length" in runtime_config.vcf_to_zarr:
+                    chunk_length_str = runtime_config.vcf_to_zarr["chunk_length"]
+                    if chunk_length_str == "default":
+                        self.chunk_length = None
+                    elif isint(chunk_length_str):
+                        self.chunk_length = int(chunk_length_str)
+                if "chunk_width" in runtime_config.vcf_to_zarr:
+                    chunk_width_str = runtime_config.vcf_to_zarr["chunk_width"]
+                    if chunk_width_str == "default":
+                        self.chunk_width = None
+                    elif isint(chunk_width_str):
+                        self.chunk_width = int(chunk_width_str)
                 if "compressor" in runtime_config.vcf_to_zarr:
                     compressor_temp = runtime_config.vcf_to_zarr["compressor"]
                     # Ensure compressor type specified is valid

--- a/benchmark/config.py
+++ b/benchmark/config.py
@@ -13,6 +13,22 @@ def config_str_to_bool(input_str):
     return input_str.lower() in ['true', '1', 't', 'y', 'yes']
 
 
+def isint(value):
+    try:
+        int(value)
+        return True
+    except ValueError:
+        return False
+
+
+def isfloat(value):
+    try:
+        float(value)
+        return True
+    except ValueError:
+        return False
+
+
 class ConfigurationRepresentation(object):
     """ A small utility class for object representation of a standard config. file. """
 
@@ -83,6 +99,7 @@ vcf_to_zarr_blosc_shuffle_types = [Blosc.NOSHUFFLE, Blosc.SHUFFLE, Blosc.BITSHUF
 class VCFtoZarrConfigurationRepresentation:
     """ Utility class for object representation of VCF to Zarr conversion module configuration. """
     enabled = False  # Specifies whether the VCF to Zarr conversion module should be enabled or not
+    alt_number = None  # Alt number to use when converting to Zarr format. If None, then this will need to be determined
     compressor = "Blosc"  # Specifies compressor type to use for Zarr conversion
     blosc_compression_algorithm = "zstd"
     blosc_compression_level = 1  # Level of compression to use for Zarr conversion
@@ -100,6 +117,14 @@ class VCFtoZarrConfigurationRepresentation:
                 # Extract relevant settings from config file
                 if "enabled" in runtime_config.vcf_to_zarr:
                     self.enabled = config_str_to_bool(runtime_config.vcf_to_zarr["enabled"])
+                if "alt_number" in runtime_config.vcf_to_zarr:
+                    alt_number_str = runtime_config.vcf_to_zarr["alt_number"]
+
+                    if str(alt_number_str).lower() in ["none", "auto"]:
+                        self.alt_number = None
+                    elif isint(alt_number_str):
+                        self.alt_number = int(alt_number_str)
+
                 if "compressor" in runtime_config.vcf_to_zarr:
                     compressor_temp = runtime_config.vcf_to_zarr["compressor"]
                     # Ensure compressor type specified is valid
@@ -110,20 +135,17 @@ class VCFtoZarrConfigurationRepresentation:
                     if blosc_compression_algorithm_temp in vcf_to_zarr_blosc_algorithm_types:
                         self.blosc_compression_algorithm = blosc_compression_algorithm_temp
                 if "blosc_compression_level" in runtime_config.vcf_to_zarr:
-                    try:
-                        compression_level_temp = int(runtime_config.vcf_to_zarr["blosc_compression_level"])
-                        if (compression_level_temp >= 0) and (compression_level_temp <= 9):
-                            self.blosc_compression_level = compression_level_temp
-                    except ValueError:
-                        pass
+                    blosc_compression_level_str = runtime_config.vcf_to_zarr["blosc_compression_level"]
+                    if isint(blosc_compression_level_str):
+                        compression_level_int = int(blosc_compression_level_str)
+                        if (compression_level_int >= 0) and (compression_level_int <= 9):
+                            self.blosc_compression_level = compression_level_int
                 if "blosc_shuffle_mode" in runtime_config.vcf_to_zarr:
-                    try:
-                        blosc_shuffle_mode_temp = int(runtime_config.vcf_to_zarr["blosc_shuffle_mode"])
-                        if blosc_shuffle_mode_temp in vcf_to_zarr_blosc_shuffle_types:
-                            self.blosc_shuffle_mode = blosc_shuffle_mode_temp
-                    except ValueError:
-                        pass
-
+                    blosc_shuffle_mode_str = runtime_config.vcf_to_zarr["blosc_shuffle_mode"]
+                    if isint(blosc_shuffle_mode_str):
+                        blosc_shuffle_mode_int = int(blosc_shuffle_mode_str)
+                        if blosc_shuffle_mode_int in vcf_to_zarr_blosc_shuffle_types:
+                            self.blosc_shuffle_mode = blosc_shuffle_mode_int
 
 
 def read_configuration(location):

--- a/benchmark/data_service.py
+++ b/benchmark/data_service.py
@@ -292,6 +292,7 @@ def convert_to_zarr(input_vcf_path, output_zarr_path, conversion_config):
         # Ensure var is string, not pathlib.Path
         output_zarr_path = str(output_zarr_path)
 
+        # Get alt number
         if conversion_config.alt_number is None:
             print("[VCF-Zarr] Determining alt number from VCF meta-information.")
             # Scan VCF file to find max number of alleles in any variant
@@ -303,6 +304,18 @@ def convert_to_zarr(input_vcf_path, output_zarr_path, conversion_config):
             # Use the configuration-provided alt number
             alt_number = conversion_config.alt_number
         print("[VCF-Zarr] Alt number: {}".format(alt_number))
+
+        # Get chunk length
+        chunk_length = allel.vcf_read.DEFAULT_CHUNK_LENGTH
+        if conversion_config.chunk_length is not None:
+            chunk_length = conversion_config.chunk_length
+        print("[VCF-Zarr] Chunk length: {}".format(chunk_length))
+
+        # Get chunk width
+        chunk_width = allel.vcf_read.DEFAULT_CHUNK_WIDTH
+        if conversion_config.chunk_width is not None:
+            chunk_width = conversion_config.chunk_width
+        print("[VCF-Zarr] Chunk width: {}".format(chunk_width))
 
         if conversion_config.compressor == "Blosc":
             compressor = Blosc(cname=conversion_config.blosc_compression_algorithm,
@@ -316,5 +329,5 @@ def convert_to_zarr(input_vcf_path, output_zarr_path, conversion_config):
         print("[VCF-Zarr] Performing VCF to Zarr conversion...")
         # Perform the VCF to Zarr conversion
         allel.vcf_to_zarr(input_vcf_path, output_zarr_path, fields='*', alt_number=alt_number,
-                          log=sys.stdout, compressor=compressor)
+                          log=sys.stdout, compressor=compressor, chunk_length=chunk_length, chunk_width=chunk_width)
         print("[VCF-Zarr] Done.")

--- a/doc/benchmark.conf
+++ b/doc/benchmark.conf
@@ -14,6 +14,8 @@ file_delimiter = |
 [vcf_to_zarr]
 enabled = False
 alt_number = None
+chunk_length = default
+chunk_width = default
 compressor = Blosc
 blosc_compression_algorithm = zstd
 blosc_compression_level = 1

--- a/doc/benchmark.conf
+++ b/doc/benchmark.conf
@@ -13,6 +13,7 @@ file_delimiter = |
 
 [vcf_to_zarr]
 enabled = False
+alt_number = None
 compressor = Blosc
 blosc_compression_algorithm = zstd
 blosc_compression_level = 1

--- a/doc/benchmark.conf.default
+++ b/doc/benchmark.conf.default
@@ -38,9 +38,17 @@ file_delimiter = |
 # benchmark tool in Setup mode.
 enabled = False
 
-# Alt number to assume when converting to Zarr format. If set to "auto" or "none", this will be determined during
-# the conversion process.
+# Alt number to assume when converting to Zarr format.
+# If set to "auto" or "none", this will be determined during the conversion process.
 alt_number = auto
+
+# Number of variants of chunks in which data are processed.
+# If set to "default", the default value from scikit-allel is used.
+chunk_length = default
+
+# Number of samples to use when storing chunks in output.
+# If set to "default", the default value from scikit-allel is used.
+chunk_width = default
 
 # Type of compression to utilize when storing Zarr-formatted data.
 #  Available Compressor Types:

--- a/doc/benchmark.conf.default
+++ b/doc/benchmark.conf.default
@@ -38,6 +38,10 @@ file_delimiter = |
 # benchmark tool in Setup mode.
 enabled = False
 
+# Alt number to assume when converting to Zarr format. If set to "auto" or "none", this will be determined during
+# the conversion process.
+alt_number = auto
+
 # Type of compression to utilize when storing Zarr-formatted data.
 #  Available Compressor Types:
 #    - Blosc


### PR DESCRIPTION
This PR exposes the alt_number, chunk_length, and chunk_width options for VCF to Zarr conversion, which was requested in https://github.com/ornl-oxford/genomics-benchmarks/pull/29#issuecomment-424490953 .

An "auto" option has been added for alt_number in the configuration file. If "auto" is specified, alt_number will be determined/calculated during the VCF to Zarr conversion process, which is what was done previously. If a number is specified, it skips this step and simply uses the provided alt number.

A "default" option has been added for chunk_length and chunk_width in the configuration file. If "default" is specified, the default value from scikit-allel is used.

Two new functions, isint() and isfloat() have been added to config.py to cleanup the code in a few places (removed redundancy).

This PR resolves #31.