### PR TITLE
Bugfix: Fix ValueError bug

### DIFF
--- a/benchmark/data_service.py
+++ b/benchmark/data_service.py
@@ -328,6 +328,6 @@ def convert_to_zarr(input_vcf_path, output_zarr_path, conversion_config):
 
         print("[VCF-Zarr] Performing VCF to Zarr conversion...")
         # Perform the VCF to Zarr conversion
-        allel.vcf_to_zarr(input_vcf_path, output_zarr_path, alt_number=alt_number,
+        allel.vcf_to_zarr(input_vcf_path, output_zarr_path, alt_number=alt_number, overwrite=True,
                           log=sys.stdout, compressor=compressor, chunk_length=chunk_length, chunk_width=chunk_width)
         print("[VCF-Zarr] Done.")

--- a/benchmark/data_service.py
+++ b/benchmark/data_service.py
@@ -328,6 +328,6 @@ def convert_to_zarr(input_vcf_path, output_zarr_path, conversion_config):
 
         print("[VCF-Zarr] Performing VCF to Zarr conversion...")
         # Perform the VCF to Zarr conversion
-        allel.vcf_to_zarr(input_vcf_path, output_zarr_path, fields='*', alt_number=alt_number,
+        allel.vcf_to_zarr(input_vcf_path, output_zarr_path, alt_number=alt_number,
                           log=sys.stdout, compressor=compressor, chunk_length=chunk_length, chunk_width=chunk_width)
         print("[VCF-Zarr] Done.")


### PR DESCRIPTION
This PR resolves #34.

**Actions taken**: removed the _fields_ parameter from the allel.vcf_to_zarr() method, which appears to resolve the issue. Also added _overwrite=True_ parameter to the function to ensure any old data is overwritten to prevent the variants/svlen error.