### PR TITLE
Ability to Limit Number of Variants and Samples for Allele Count and PCA Benchmarks

### DIFF
--- a/genomics_benchmarks/config.py
+++ b/genomics_benchmarks/config.py
@@ -206,8 +206,8 @@ GENOTYPE_ARRAY_NORMAL = 0
 GENOTYPE_ARRAY_DASK = 1
 GENOTYPE_ARRAY_CHUNKED = 2
 genotype_array_types = {GENOTYPE_ARRAY_NORMAL,
-                                      GENOTYPE_ARRAY_DASK,
-                                      GENOTYPE_ARRAY_CHUNKED}
+                        GENOTYPE_ARRAY_DASK,
+                        GENOTYPE_ARRAY_CHUNKED}
 
 
 class BenchmarkConfigurationRepresentation:
@@ -215,6 +215,8 @@ class BenchmarkConfigurationRepresentation:
     benchmark_number_runs = 5
     benchmark_data_input = "vcf"
     benchmark_dataset = ""
+    benchmark_num_variants = -1
+    benchmark_num_samples = -1
     benchmark_aggregations = False
     benchmark_pca = False
     genotype_array_type = GENOTYPE_ARRAY_DASK
@@ -249,6 +251,24 @@ class BenchmarkConfigurationRepresentation:
                         self.benchmark_data_input = benchmark_data_input_temp
                 if "benchmark_dataset" in runtime_config.benchmark:
                     self.benchmark_dataset = runtime_config.benchmark["benchmark_dataset"]
+                if "benchmark_num_variants" in runtime_config.benchmark:
+                    benchmark_num_variants_str = runtime_config.benchmark["benchmark_num_variants"]
+                    if isint(benchmark_num_variants_str) and (
+                            int(benchmark_num_variants_str) == -1 or int(benchmark_num_variants_str) >= 1):
+                        self.benchmark_num_variants = int(benchmark_num_variants_str)
+                    else:
+                        raise ValueError("Invalid value for benchmark_num_variants in configuration.\n"
+                                         "benchmark_num_variants must be a valid integer greater than 1.\n"
+                                         "Alternatively, a value of -1 can be specified to include all variants.")
+                if "benchmark_num_samples" in runtime_config.benchmark:
+                    benchmark_num_samples_str = runtime_config.benchmark["benchmark_num_samples"]
+                    if isint(benchmark_num_samples_str) and (
+                            int(benchmark_num_samples_str) == -1 or int(benchmark_num_samples_str) >= 1):
+                        self.benchmark_num_samples = int(benchmark_num_samples_str)
+                    else:
+                        raise ValueError("Invalid value for benchmark_num_samples in configuration.\n"
+                                         "benchmark_num_samples must be a valid integer greater than 1.\n"
+                                         "Alternatively, a value of -1 can be specified to include all samples.")
                 if "benchmark_aggregations" in runtime_config.benchmark:
                     self.benchmark_aggregations = config_str_to_bool(runtime_config.benchmark["benchmark_aggregations"])
                 if "benchmark_pca" in runtime_config.benchmark:

--- a/genomics_benchmarks/config/benchmark.conf.default
+++ b/genomics_benchmarks/config/benchmark.conf.default
@@ -94,6 +94,15 @@ benchmark_data_input = vcf
 # Specifies which dataset to use for the benchmarking process.
 benchmark_dataset =
 
+# Specifies the number of variants to include from the dataset input for benchmarking.
+# If a value of -1 is passed, then all variants will be included.
+benchmark_num_variants = -1
+
+# Specifies the number of samples to include from the dataset input for benchmarking.
+# If a value of -1 is passed, then all samples will be included.
+benchmark_num_samples = -1
+
+
 # Enables/disables running simple aggregations, such as allele count and genotype count, 
 # as part of the benchmarking process.
 benchmark_aggregations = True


### PR DESCRIPTION
This PR tackles the early steps for Part 1 and Part 2 of the benchmarking steps mentioned in https://github.com/ornl-oxford/genomics-benchmarks/issues/43#issuecomment-454563777. This implements the ability for a user to limit the number of variants and samples for the allele count and PCA benchmarks.