### PR TITLE
Make LD Pruning Optional

### DIFF
--- a/genomics_benchmarks/config.py
+++ b/genomics_benchmarks/config.py
@@ -224,6 +224,7 @@ class BenchmarkConfigurationRepresentation:
     pca_number_components = 10
     pca_data_scaler = benchmark_pca_data_scaler_types[PCA_DATA_SCALER_PATTERSON]
     pca_subset_size = 100000
+    pca_ld_enabled = False
     pca_ld_pruning_number_iterations = 2
     pca_ld_pruning_size = 100
     pca_ld_pruning_step = 20
@@ -282,6 +283,8 @@ class BenchmarkConfigurationRepresentation:
                     else:
                         raise ValueError("Invalid value for pca_subset_size in configuration.\n"
                                          "pca_subset_size must be a valid integer greater than 0.")
+                if "pca_ld_enabled" in runtime_config.benchmark:
+                    self.pca_ld_enabled = config_str_to_bool(runtime_config.benchmark["pca_ld_enabled"])
                 if "pca_ld_pruning_number_iterations" in runtime_config.benchmark:
                     pca_ld_pruning_number_iterations_str = runtime_config.benchmark["pca_ld_pruning_number_iterations"]
                     if isint(pca_ld_pruning_number_iterations_str) and (int(pca_ld_pruning_number_iterations_str) > 0):

--- a/genomics_benchmarks/config/benchmark.conf.default
+++ b/genomics_benchmarks/config/benchmark.conf.default
@@ -122,6 +122,10 @@ pca_data_scaler = 1
 # If the size of the data set is smaller than pca_subset_size, that will be used instead.
 pca_subset_size = 100000
 
+# [PCA Benchmark: Linkage Disequilibrium] Specifies whether to enable or disable LD pruning operation.
+# Note: The LD pruning implementation is not parallelized and may not scale well when running on multi-node systems.
+pca_ld_enabled = False
+
 # [PCA Benchmark: Linkage Disequilibrium] Sets the number of iterations to perform LD pruning.
 pca_ld_pruning_number_iterations = 2
 

--- a/genomics_benchmarks/core.py
+++ b/genomics_benchmarks/core.py
@@ -287,18 +287,22 @@ class Benchmark:
         vidx.sort()
         gnr = gn.take(vidx, axis=0)
 
-        if self.bench_conf.genotype_array_type != config.GENOTYPE_ARRAY_DASK:
-            # Apply LD pruning to subset of SNPs
-            size = self.bench_conf.pca_ld_pruning_size
-            step = self.bench_conf.pca_ld_pruning_step
-            threshold = self.bench_conf.pca_ld_pruning_threshold
-            n_iter = self.bench_conf.pca_ld_pruning_number_iterations
+        if self.bench_conf.pca_ld_enabled:
+            if self.bench_conf.genotype_array_type != config.GENOTYPE_ARRAY_DASK:
+                # Apply LD pruning to subset of SNPs
+                size = self.bench_conf.pca_ld_pruning_size
+                step = self.bench_conf.pca_ld_pruning_step
+                threshold = self.bench_conf.pca_ld_pruning_threshold
+                n_iter = self.bench_conf.pca_ld_pruning_number_iterations
 
-            self.benchmark_profiler.start_benchmark('PCA: Apply LD pruning')
-            gnu = self._pca_ld_prune(gnr, size=size, step=step, threshold=threshold, n_iter=n_iter)
-            self.benchmark_profiler.end_benchmark()
+                self.benchmark_profiler.start_benchmark('PCA: Apply LD pruning')
+                gnu = self._pca_ld_prune(gnr, size=size, step=step, threshold=threshold, n_iter=n_iter)
+                self.benchmark_profiler.end_benchmark()
+            else:
+                print('[Exec][PCA] Cannot apply LD pruning because Dask genotype arrays do not support this operation.')
+                gnu = gnr
         else:
-            print('[Exec][PCA] Cannot apply LD pruning because Dask genotype arrays do not support this operation.')
+            print('[Exec][PCA] LD pruning disabled. Skipping this operation.')
             gnu = gnr
 
         # If data is chunked, move to memory for PCA

--- a/genomics_benchmarks/core.py
+++ b/genomics_benchmarks/core.py
@@ -315,7 +315,13 @@ class Benchmark:
         n = min(gn.shape[0], self.bench_conf.pca_subset_size)
         vidx = np.random.choice(gn.shape[0], n, replace=False)
         vidx.sort()
-        gnr = gn.take(vidx, axis=0)
+        if self.bench_conf.genotype_array_type in [config.GENOTYPE_ARRAY_NORMAL, config.GENOTYPE_ARRAY_CHUNKED]:
+            gnr = gn.take(vidx, axis=0)
+        elif self.bench_conf.genotype_array_type == config.GENOTYPE_ARRAY_DASK:
+            gnr = gn[vidx]  # Use indexing workaround since Dask Array's take() method is not working properly
+        else:
+            print('[Exec][PCA] Error: Unspecified genotype array type specified.')
+            exit(1)
 
         if self.bench_conf.pca_ld_enabled:
             if self.bench_conf.genotype_array_type != config.GENOTYPE_ARRAY_DASK:

--- a/tests/data/config_test_reading_runtime.conf
+++ b/tests/data/config_test_reading_runtime.conf
@@ -31,6 +31,7 @@ genotype_array_type = 2
 pca_number_components = 10
 pca_data_scaler = 1
 pca_subset_size = 100000
+pca_ld_enabled = False
 pca_ld_pruning_number_iterations = 2
 pca_ld_pruning_size = 100
 pca_ld_pruning_step = 20

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -232,6 +232,7 @@ class TestCoreBenchmark(unittest.TestCase):
         bench_conf.benchmark_pca = True
         bench_conf.pca_data_scaler = config.benchmark_pca_data_scaler_types[config.PCA_DATA_SCALER_PATTERSON]
         bench_conf.genotype_array_type = config.GENOTYPE_ARRAY_CHUNKED
+        bench_conf.pca_ld_enabled = True
 
         data_dirs = DataDirectoriesConfigurationRepresentation()
         data_dirs.vcf_dir = './tests/data/'


### PR DESCRIPTION
This PR allows the LD pruning operation within the PCA benchmark to be enabled/disabled via the benchmark configuration file. This is useful because LD pruning within scikit-allel is not parallelized and is not yet scalable for operation on larger systems.

This will also be useful if the PCA implementation is updated to use the Dask framework, effectively allowing PCA to be usable on large, distributed systems. In this scenario, LD pruning can now be disabled.